### PR TITLE
Change recipe ingredient amount from float to decimal + other improvements

### DIFF
--- a/app/models/ingredient_category.rb
+++ b/app/models/ingredient_category.rb
@@ -3,7 +3,7 @@
 class IngredientCategory < ApplicationRecord
   has_many :ingredients
 
-  validates_presence_of :name
+  validates :name, presence: true
 
   scope :lasting, -> { where(is_lasting: true) }
   scope :used, -> { joins(:ingredients).where("ingredients.id IS NOT NULL").distinct.any? }

--- a/app/models/recipe_ingredient.rb
+++ b/app/models/recipe_ingredient.rb
@@ -6,7 +6,7 @@ class RecipeIngredient < ApplicationRecord
   belongs_to :recipe
   belongs_to :ingredient
 
-  validates_presence_of :amount
+  validates :amount, presence: true
 
   scope :measured, -> { where.not(amount: nil) }
 

--- a/app/views/index/changelog.html.slim
+++ b/app/views/index/changelog.html.slim
@@ -1,6 +1,23 @@
 - content_for :title, "co je nového?"
 
 .mb-5
+  h2 průběžné úpravy a opravy (2. 1. 2025)
+  | Nic velkého, ale i
+  span.italic =< "navařit"
+  | potřebuje občas trochu péče.
+
+  p
+    ul.list-disc.pl-4
+    li.my-2 Pokud jste měli registraci přes Google, a snažili jste se přihlásit heslem, ukazovala se stránka "Něco se rozbilo". Po opravě už se zobrazuje správně informace o chybném hesle, což snad lépe popisuje, co je za problém.
+      br
+      | Tip: Vždycky si můžete přes "zapomenuté heslo" nechat poslat do mailu návod, jak si změnit (nebo vytvořit) heslo, pokud se do účtu nemůžete dostat.
+    li.my-2 Pod kapotou jsme aktualizovali používané knihovny na nejnovější verze, což je nutnost pro dlouhodobé udržení moderní, bezpečné a funkční aplikace
+    li.my-2 Recepty jde nově zveřejnit jen pokud mají suroviny a popis.
+    li.my-2 Množství surovin jsem dosud ukládal jako desetinné číslo s více desetinnými místy, což ale občas vede k divným zaokrouhlením. Měním je tedy na číslo se dvěma desetinnými místy, což by mělo pro přesnost receptů stačit. Může se ale stát, že se někomu číslo drobně změní.
+
+hr
+
+.mb-5
   h2 dejte nám zpětnou vazbu! (1. 11. 2024)
   p
     | Něco se vám nelíbí? Něco vám chybí? Něco nefunguje?

--- a/app/views/shared/_navbar.html.slim
+++ b/app/views/shared/_navbar.html.slim
@@ -15,8 +15,8 @@ nav.mb-4.hidden.sm:block
                 = current_user.name || current_user.email
                 = icon("caret-down", class: "ml-1 w-4 h-4 text-white")
 
-            div id="dropdown" class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-gray-700"
-                ul class="py-2 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownDefaultButton"
+            div id="dropdown" class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow w-44"
+                ul class="py-2 text-sm text-gray-700" aria-labelledby="dropdownDefaultButton"
                     li.ps-2
                         = link_to feedback_path, class: "hover:underline hover:emerald-600 hover:decoration-emerald-700 hover:decoration-4" do
                             = "feedback"

--- a/db/migrate/20250102175119_change_recipe_ingredient_amount_from_float_to_decimal.rb
+++ b/db/migrate/20250102175119_change_recipe_ingredient_amount_from_float_to_decimal.rb
@@ -1,0 +1,5 @@
+class ChangeRecipeIngredientAmountFromFloatToDecimal < ActiveRecord::Migration[8.0]
+  def change
+    change_column :recipes_have_ingredients, :amount, :decimal, precision: 12, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_01_193837) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_02_175119) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -277,7 +277,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_01_193837) do
   create_table "recipes_have_ingredients", primary_key: ["recipe_id", "ingredient_id"], charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "recipe_id", null: false
     t.integer "ingredient_id", null: false
-    t.float "amount"
+    t.decimal "amount", precision: 12, scale: 2
     t.string "comment"
     t.index ["ingredient_id"], name: "ix_recipes_have_ingredients_ingredient_id"
     t.index ["recipe_id"], name: "ix_recipes_have_ingredients_recipe_id"


### PR DESCRIPTION
Změna recipe_ingredient.amount z FLOAT na DECIMAL, abychom měli lepší zaokrouhlování
closes https://github.com/janpeterka/navarit/issues/90

Smazání `dark:` tříd v navbar dropdownu, aby to neukazovalo nečitelně.
closes https://github.com/janpeterka/navarit/issues/109