### PR TITLE
Extend event timetable if task is outside it

### DIFF
--- a/app/views/events/_day_card.html.slim
+++ b/app/views/events/_day_card.html.slim
@@ -23,5 +23,5 @@
 
       - if can? :update, daily_plan
         ul.mt-2
-          li.px-3.invisible.group-hover:visible
+          li.px-3.md:invisible.group-hover:visible
             = button_link_to "přidat jídlo", daily_plan_path(daily_plan), icon: :plus, type: :plain, data: { turbo_frame: "modal" }, class: "border-none hover:bg-ocean-200 py-3"

--- a/test/models/event_timetable_test.rb
+++ b/test/models/event_timetable_test.rb
@@ -25,4 +25,14 @@ class EventTimetableTest < ActiveSupport::TestCase
 
     assert @event.timetable.days.find { _1.date == Date.new(2024, 1, 2) }.tasks == [ recipe_task ]
   end
+
+  test "assign recipe task when task is before expected range" do
+    recipe = FactoryBot.create(:hummus_with_carrot, author: @current_user)
+    recipe_task = recipe.tasks.create!(name: "Buy carrot one day before", days_before_cooking: 2)
+
+    date = @event.begins_at
+    @event.daily_plans.find_by(date:).daily_plan_recipes.create!(recipe:, portion_count: 12)
+
+    assert @event.timetable.days.find { _1.date == date - 2.days }.tasks == [ recipe_task ]
+  end
 end


### PR DESCRIPTION
Když se úkol ke dni nevešel do timetable, tak se stránka eventu nenačetla. 
Opravuju generováním rozsahu akce podle tasků.
To nejspíš stránku zpomalí, ale to budu řešit až později..